### PR TITLE
Add modules stock_packaging_usability and stock_packaging_usability_ul

### DIFF
--- a/stock_packaging_usability/README.rst
+++ b/stock_packaging_usability/README.rst
@@ -1,0 +1,38 @@
+Stock Packaging Usability
+=========================
+
+Usage
+=====
+
+This module adds 2 buttons in the *Transfer* wizard of the picking:
+
+* *Put in current pack* (this button is native in v7 but not in v8)
+
+* *Put residual in new pack* : all the lines that are not in a package
+    will be put in a new package.
+
+So this module is a time saver when you use the packaging features of Odoo !
+For example, on a picking where all the products go in the same package, you
+just have to click on the button *Put residual in new pack* and you're done:
+no need to click on each line !
+
+Credits
+=======
+
+Contributors
+------------
+
+* Alexis de Lattre <alexis.delattre@akretion.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/stock_packaging_usability/__init__.py
+++ b/stock_packaging_usability/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Stock Packaging Usability module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import wizard

--- a/stock_packaging_usability/__openerp__.py
+++ b/stock_packaging_usability/__openerp__.py
@@ -1,0 +1,50 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Stock Packaging Usability module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com).
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Stock Packaging Usability',
+    'version': '1.0',
+    'category': 'Warehouse Management',
+    'license': 'AGPL-3',
+    'summary': "Faster packaging process in Odoo",
+    'description': """
+This module adds 2 buttons in the *Transfer* wizard of the picking:
+
+* *Put in current pack* (this button is native in v7 but not in v8)
+
+* *Put residual in new pack* : all the lines that are not in a package
+    will be put in a new package.
+
+So this module is a time saver when you use the packaging features of Odoo !
+For example, on a picking where all the products go in the same package, you
+just have to click on the button *Put residual in new pack* and you're done:
+no need to click on each line !
+
+This module has been written by Alexis de Lattre from Akretion
+<alexis.delattre@akretion.com>
+    """,
+    'author': 'Akretion',
+    'website': 'http://www.akretion.com',
+    'depends': ['stock'],
+    'data': ['wizard/stock_transfer_details.xml'],
+    'installable': True,
+}

--- a/stock_packaging_usability/__openerp__.py
+++ b/stock_packaging_usability/__openerp__.py
@@ -26,22 +26,6 @@
     'category': 'Warehouse Management',
     'license': 'AGPL-3',
     'summary': "Faster packaging process in Odoo",
-    'description': """
-This module adds 2 buttons in the *Transfer* wizard of the picking:
-
-* *Put in current pack* (this button is native in v7 but not in v8)
-
-* *Put residual in new pack* : all the lines that are not in a package
-    will be put in a new package.
-
-So this module is a time saver when you use the packaging features of Odoo !
-For example, on a picking where all the products go in the same package, you
-just have to click on the button *Put residual in new pack* and you're done:
-no need to click on each line !
-
-This module has been written by Alexis de Lattre from Akretion
-<alexis.delattre@akretion.com>
-    """,
     'author': 'Akretion',
     'website': 'http://www.akretion.com',
     'depends': ['stock'],

--- a/stock_packaging_usability/i18n/fr.po
+++ b/stock_packaging_usability/i18n/fr.po
@@ -1,0 +1,64 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_packaging_usability
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-21 08:57+0000\n"
+"PO-Revision-Date: 2014-11-21 08:57+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_packaging_usability
+#: model:ir.model,name:stock_packaging_usability.model_stock_transfer_details
+msgid "Picking wizard"
+msgstr "Picking wizard"
+
+#. module: stock_packaging_usability
+#: model:ir.model,name:stock_packaging_usability.model_stock_transfer_details_items
+msgid "Picking wizard items"
+msgstr "Picking wizard items"
+
+#. module: stock_packaging_usability
+#: view:stock.transfer_details:stock_packaging_usability.view_stock_enter_transfer_details
+msgid "Products To Move"
+msgstr "Produits à déplacer"
+
+#. module: stock_packaging_usability
+#: view:stock.transfer_details:stock_packaging_usability.view_stock_enter_transfer_details
+msgid "Put Residual in New Pack"
+msgstr "Mettre le reste dans un nouveau paquet"
+
+#. module: stock_packaging_usability
+#: view:stock.transfer_details:stock_packaging_usability.view_stock_enter_transfer_details
+msgid "Put in current pack"
+msgstr "Mettre dans le paquet actuel"
+
+#. module: stock_packaging_usability
+#: view:stock.transfer_details:stock_packaging_usability.view_stock_enter_transfer_details
+msgid "Put in new pack"
+msgstr "Mettre dans un nouveau paquet"
+
+#. module: stock_packaging_usability
+#: code:addons/stock_packaging_usability/wizard/stock_transfer_details.py:58
+#, python-format
+msgid "There is no current package"
+msgstr "Il n'y a pas de paquet actuel"
+
+#. module: stock_packaging_usability
+#: code:addons/stock_packaging_usability/wizard/stock_transfer_details.py:52
+#, python-format
+msgid "This product is already in a package !"
+msgstr "Ce produit est déjà dans un paquet !"
+
+#. module: stock_packaging_usability
+#: view:stock.transfer_details:stock_packaging_usability.view_stock_enter_transfer_details
+msgid "terp-accessories-archiver+"
+msgstr "terp-accessories-archiver+"
+

--- a/stock_packaging_usability/i18n/fr.po
+++ b/stock_packaging_usability/i18n/fr.po
@@ -18,12 +18,12 @@ msgstr ""
 #. module: stock_packaging_usability
 #: model:ir.model,name:stock_packaging_usability.model_stock_transfer_details
 msgid "Picking wizard"
-msgstr "Picking wizard"
+msgstr ""
 
 #. module: stock_packaging_usability
 #: model:ir.model,name:stock_packaging_usability.model_stock_transfer_details_items
 msgid "Picking wizard items"
-msgstr "Picking wizard items"
+msgstr ""
 
 #. module: stock_packaging_usability
 #: view:stock.transfer_details:stock_packaging_usability.view_stock_enter_transfer_details

--- a/stock_packaging_usability/i18n/stock_packaging_usability.pot
+++ b/stock_packaging_usability/i18n/stock_packaging_usability.pot
@@ -1,0 +1,64 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_packaging_usability
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-21 08:57+0000\n"
+"PO-Revision-Date: 2014-11-21 08:57+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_packaging_usability
+#: model:ir.model,name:stock_packaging_usability.model_stock_transfer_details
+msgid "Picking wizard"
+msgstr ""
+
+#. module: stock_packaging_usability
+#: model:ir.model,name:stock_packaging_usability.model_stock_transfer_details_items
+msgid "Picking wizard items"
+msgstr ""
+
+#. module: stock_packaging_usability
+#: view:stock.transfer_details:stock_packaging_usability.view_stock_enter_transfer_details
+msgid "Products To Move"
+msgstr ""
+
+#. module: stock_packaging_usability
+#: view:stock.transfer_details:stock_packaging_usability.view_stock_enter_transfer_details
+msgid "Put Residual in New Pack"
+msgstr ""
+
+#. module: stock_packaging_usability
+#: view:stock.transfer_details:stock_packaging_usability.view_stock_enter_transfer_details
+msgid "Put in current pack"
+msgstr ""
+
+#. module: stock_packaging_usability
+#: view:stock.transfer_details:stock_packaging_usability.view_stock_enter_transfer_details
+msgid "Put in new pack"
+msgstr ""
+
+#. module: stock_packaging_usability
+#: code:addons/stock_packaging_usability/wizard/stock_transfer_details.py:58
+#, python-format
+msgid "There is no current package"
+msgstr ""
+
+#. module: stock_packaging_usability
+#: code:addons/stock_packaging_usability/wizard/stock_transfer_details.py:52
+#, python-format
+msgid "This product is already in a package !"
+msgstr ""
+
+#. module: stock_packaging_usability
+#: view:stock.transfer_details:stock_packaging_usability.view_stock_enter_transfer_details
+msgid "terp-accessories-archiver+"
+msgstr ""
+

--- a/stock_packaging_usability/wizard/__init__.py
+++ b/stock_packaging_usability/wizard/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Stock Packaging Usability module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import stock_transfer_details

--- a/stock_packaging_usability/wizard/stock_transfer_details.py
+++ b/stock_packaging_usability/wizard/stock_transfer_details.py
@@ -1,0 +1,62 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Stock Packaging Usability module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api, _
+from openerp.exceptions import Warning
+
+
+class StockTransferDetails(models.TransientModel):
+    _inherit = 'stock.transfer_details'
+
+    @api.multi
+    def put_residual_in_new_pack(self):
+        for wiz in self:
+            items_to_update = wiz.item_ids
+            for item in wiz.item_ids:
+                if item.result_package_id:
+                    items_to_update -= item
+                if not item.quantity:
+                    items_to_update -= item
+            items_to_update.put_in_pack()
+        if self and self[0]:
+            return self[0].wizard_view()
+
+
+class StockTransferDetailsItems(models.TransientModel):
+    _inherit = 'stock.transfer_details_items'
+
+    @api.multi
+    def put_in_last_pack(self):
+        for packop in self:
+            if packop.result_package_id:
+                raise Warning(
+                    _('This product is already in a package !'))
+            all_cur_packs_ids = [
+                packop2.result_package_id.id for packop2
+                in self.transfer_id.item_ids if packop2.result_package_id]
+            if not all_cur_packs_ids:
+                raise Warning(
+                    _('There is no current package'))
+            all_cur_packs_ids.sort()
+            packop.result_package_id = all_cur_packs_ids[-1]
+        if self and self[0]:
+            return self[0].transfer_id.wizard_view()

--- a/stock_packaging_usability/wizard/stock_transfer_details.xml
+++ b/stock_packaging_usability/wizard/stock_transfer_details.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright (C) 2014 Akretion (http://www.akretion.com/)
+    @author Alexis de Lattre <alexis.delattre@akretion.com>
+    The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data>
+
+
+<record id="view_stock_enter_transfer_details" model="ir.ui.view">
+    <field name="name">stock_packaging_usability.stock.transfer_details</field>
+    <field name="model">stock.transfer_details</field>
+    <field name="inherit_id" ref="stock.view_stock_enter_transfer_details" />
+    <field name="arch" type="xml">
+        <group string="Products To Move" position="inside">
+            <button type="object" name="put_residual_in_new_pack"
+                string="Put Residual in New Pack"
+                groups="stock.group_tracking_lot"/>
+        </group>
+        <button name="put_in_pack" type="object" position="before">
+            <button name="put_in_last_pack" type="object"
+                string="Put in current pack"
+                icon="terp-accessories-archiver"
+                groups="stock.group_tracking_lot"
+                attrs="{'invisible': [('result_package_id', '!=', False)]}"/>
+        </button>
+        <button name="put_in_pack" type="object" position="attributes">
+            <attribute name="string">Put in new pack</attribute>
+        </button>
+        <button name="put_in_pack" type="object" position="attributes">
+            <attribute name="icon">terp-accessories-archiver+</attribute>
+        </button>
+    </field>
+</record>
+
+
+</data>
+</openerp>

--- a/stock_packaging_usability_ul/README.rst
+++ b/stock_packaging_usability_ul/README.rst
@@ -1,0 +1,32 @@
+Stock Packaging Usability UL
+============================
+
+Usage
+=====
+
+This module modifies the behavior of the buttons *Put in new pack*
+(native button) and *Put residual in one pack* (provided by the module
+*stock_packing_usability*) of the *Transfer* wizard : when you clicks
+on those buttons, it will ask you to select the logistical unit (object
+*product.ul*) of the package.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Alexis de Lattre <alexis.delattre@akretion.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/stock_packaging_usability_ul/__init__.py
+++ b/stock_packaging_usability_ul/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Stock Packaging Usability UL module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import wizard

--- a/stock_packaging_usability_ul/__openerp__.py
+++ b/stock_packaging_usability_ul/__openerp__.py
@@ -26,15 +26,6 @@
     'category': 'Warehouse Management',
     'license': 'AGPL-3',
     'summary': "Faster packaging process with logistical units",
-    'description': """
-This module modifies the behavior of the 2 buttons *Put in new pack*
-(native button) and *Put residual in one pack* (provided by the module
-*stock_packing_usability*) : it will ask the user to select the
-logistical unit (object *product.ul*) of the package.
-
-This module has been written by Alexis de Lattre from Akretion
-<alexis.delattre@akretion.com>
-    """,
     'author': 'Akretion',
     'website': 'http://www.akretion.com',
     'depends': ['stock_packaging_usability'],

--- a/stock_packaging_usability_ul/__openerp__.py
+++ b/stock_packaging_usability_ul/__openerp__.py
@@ -1,0 +1,46 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Stock Packaging Usability UL module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com).
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Stock Packaging Usability UL',
+    'version': '1.0',
+    'category': 'Warehouse Management',
+    'license': 'AGPL-3',
+    'summary': "Faster packaging process with logistical units",
+    'description': """
+This module modifies the behavior of the 2 buttons *Put in new pack*
+(native button) and *Put residual in one pack* (provided by the module
+*stock_packing_usability*) : it will ask the user to select the
+logistical unit (object *product.ul*) of the package.
+
+This module has been written by Alexis de Lattre from Akretion
+<alexis.delattre@akretion.com>
+    """,
+    'author': 'Akretion',
+    'website': 'http://www.akretion.com',
+    'depends': ['stock_packaging_usability'],
+    'data': [
+        'wizard/stock_select_ul.xml',
+        'wizard/stock_transfer_details.xml',
+        ],
+    'installable': True,
+}

--- a/stock_packaging_usability_ul/i18n/fr.po
+++ b/stock_packaging_usability_ul/i18n/fr.po
@@ -23,12 +23,12 @@ msgstr "Annuler"
 #. module: stock_packaging_usability_ul
 #: field:stock.select.ul,create_uid:0
 msgid "Created by"
-msgstr "Created by"
+msgstr "Créé par"
 
 #. module: stock_packaging_usability_ul
 #: field:stock.select.ul,create_date:0
 msgid "Created on"
-msgstr "Created on"
+msgstr "Créé le"
 
 #. module: stock_packaging_usability_ul
 #: field:stock.select.ul,id:0
@@ -38,12 +38,12 @@ msgstr "ID"
 #. module: stock_packaging_usability_ul
 #: field:stock.select.ul,write_uid:0
 msgid "Last Updated by"
-msgstr "Last Updated by"
+msgstr "Dernière mise-à-jour par"
 
 #. module: stock_packaging_usability_ul
 #: field:stock.select.ul,write_date:0
 msgid "Last Updated on"
-msgstr "Last Updated on"
+msgstr "Dernière mise-à-jour le"
 
 #. module: stock_packaging_usability_ul
 #: field:stock.select.ul,ul_id:0
@@ -53,12 +53,12 @@ msgstr "Unité logistique"
 #. module: stock_packaging_usability_ul
 #: model:ir.model,name:stock_packaging_usability_ul.model_stock_transfer_details
 msgid "Picking wizard"
-msgstr "Picking wizard"
+msgstr ""
 
 #. module: stock_packaging_usability_ul
 #: model:ir.model,name:stock_packaging_usability_ul.model_stock_transfer_details_items
 msgid "Picking wizard items"
-msgstr "Picking wizard items"
+msgstr ""
 
 #. module: stock_packaging_usability_ul
 #: model:ir.actions.act_window,name:stock_packaging_usability_ul.stock_select_ul_action

--- a/stock_packaging_usability_ul/i18n/fr.po
+++ b/stock_packaging_usability_ul/i18n/fr.po
@@ -1,0 +1,93 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_packaging_usability_ul
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-21 09:06+0000\n"
+"PO-Revision-Date: 2014-11-21 09:06+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_packaging_usability_ul
+#: view:stock.select.ul:stock_packaging_usability_ul.stock_select_ul_form
+msgid "Cancel"
+msgstr "Annuler"
+
+#. module: stock_packaging_usability_ul
+#: field:stock.select.ul,create_uid:0
+msgid "Created by"
+msgstr "Created by"
+
+#. module: stock_packaging_usability_ul
+#: field:stock.select.ul,create_date:0
+msgid "Created on"
+msgstr "Created on"
+
+#. module: stock_packaging_usability_ul
+#: field:stock.select.ul,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: stock_packaging_usability_ul
+#: field:stock.select.ul,write_uid:0
+msgid "Last Updated by"
+msgstr "Last Updated by"
+
+#. module: stock_packaging_usability_ul
+#: field:stock.select.ul,write_date:0
+msgid "Last Updated on"
+msgstr "Last Updated on"
+
+#. module: stock_packaging_usability_ul
+#: field:stock.select.ul,ul_id:0
+msgid "Logistic Unit"
+msgstr "Unité logistique"
+
+#. module: stock_packaging_usability_ul
+#: model:ir.model,name:stock_packaging_usability_ul.model_stock_transfer_details
+msgid "Picking wizard"
+msgstr "Picking wizard"
+
+#. module: stock_packaging_usability_ul
+#: model:ir.model,name:stock_packaging_usability_ul.model_stock_transfer_details_items
+msgid "Picking wizard items"
+msgstr "Picking wizard items"
+
+#. module: stock_packaging_usability_ul
+#: model:ir.actions.act_window,name:stock_packaging_usability_ul.stock_select_ul_action
+#: view:stock.select.ul:stock_packaging_usability_ul.stock_select_ul_form
+msgid "Select Logistical Unit"
+msgstr "Sélectionnez l'unité logistique"
+
+#. module: stock_packaging_usability_ul
+#: model:ir.model,name:stock_packaging_usability_ul.model_stock_select_ul
+msgid "Select UL"
+msgstr "Sélectionnez l'unité logistique"
+
+#. module: stock_packaging_usability_ul
+#: view:stock.select.ul:stock_packaging_usability_ul.stock_select_ul_form
+msgid "Validate"
+msgstr "Valider"
+
+#. module: stock_packaging_usability_ul
+#: view:stock.transfer_details:stock_packaging_usability_ul.view_stock_enter_transfer_details
+msgid "action"
+msgstr "action"
+
+#. module: stock_packaging_usability_ul
+#: view:stock.transfer_details:stock_packaging_usability_ul.view_stock_enter_transfer_details
+msgid "{'pack_function': 'put_in_pack'}"
+msgstr "{'pack_function': 'put_in_pack'}"
+
+#. module: stock_packaging_usability_ul
+#: view:stock.transfer_details:stock_packaging_usability_ul.view_stock_enter_transfer_details
+msgid "{'pack_function': 'put_residual_in_new_pack'}"
+msgstr "{'pack_function': 'put_residual_in_new_pack'}"
+

--- a/stock_packaging_usability_ul/i18n/stock_packaging_usability_ul.pot
+++ b/stock_packaging_usability_ul/i18n/stock_packaging_usability_ul.pot
@@ -1,0 +1,93 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_packaging_usability_ul
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-21 09:05+0000\n"
+"PO-Revision-Date: 2014-11-21 09:05+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_packaging_usability_ul
+#: view:stock.select.ul:stock_packaging_usability_ul.stock_select_ul_form
+msgid "Cancel"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: field:stock.select.ul,create_uid:0
+msgid "Created by"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: field:stock.select.ul,create_date:0
+msgid "Created on"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: field:stock.select.ul,id:0
+msgid "ID"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: field:stock.select.ul,write_uid:0
+msgid "Last Updated by"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: field:stock.select.ul,write_date:0
+msgid "Last Updated on"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: field:stock.select.ul,ul_id:0
+msgid "Logistic Unit"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: model:ir.model,name:stock_packaging_usability_ul.model_stock_transfer_details
+msgid "Picking wizard"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: model:ir.model,name:stock_packaging_usability_ul.model_stock_transfer_details_items
+msgid "Picking wizard items"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: model:ir.actions.act_window,name:stock_packaging_usability_ul.stock_select_ul_action
+#: view:stock.select.ul:stock_packaging_usability_ul.stock_select_ul_form
+msgid "Select Logistical Unit"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: model:ir.model,name:stock_packaging_usability_ul.model_stock_select_ul
+msgid "Select UL"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: view:stock.select.ul:stock_packaging_usability_ul.stock_select_ul_form
+msgid "Validate"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: view:stock.transfer_details:stock_packaging_usability_ul.view_stock_enter_transfer_details
+msgid "action"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: view:stock.transfer_details:stock_packaging_usability_ul.view_stock_enter_transfer_details
+msgid "{'pack_function': 'put_in_pack'}"
+msgstr ""
+
+#. module: stock_packaging_usability_ul
+#: view:stock.transfer_details:stock_packaging_usability_ul.view_stock_enter_transfer_details
+msgid "{'pack_function': 'put_residual_in_new_pack'}"
+msgstr ""
+

--- a/stock_packaging_usability_ul/wizard/__init__.py
+++ b/stock_packaging_usability_ul/wizard/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Stock Packaging Usability UL module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import stock_select_ul

--- a/stock_packaging_usability_ul/wizard/stock_select_ul.py
+++ b/stock_packaging_usability_ul/wizard/stock_select_ul.py
@@ -54,3 +54,21 @@ class StockSelectUL(models.TransientModel):
             trf_line_wiz.put_in_pack()
             action = trf_line_wiz.transfer_id.wizard_view()
         return action
+
+    @api.multi
+    def cancel(self):
+        """We have to re-call the wizard when the user clicks on Cancel"""
+        self.ensure_one()
+        if self.env.context.get('pack_function') == 'put_residual_in_new_pack':
+            assert self.env.context.get('active_model') == \
+                'stock.transfer_details', 'Wrong underlying model'
+            trf_wiz = self.env['stock.transfer_details'].browse(
+                self.env.context['active_id'])
+            action = trf_wiz.wizard_view()
+        elif self.env.context.get('pack_function') == 'put_in_pack':
+            assert self.env.context.get('active_model') == \
+                'stock.transfer_details_items', 'Wrong underlying model'
+            trf_line_wiz = self.env['stock.transfer_details_items'].browse(
+                self.env.context['active_id'])
+            action = trf_line_wiz.transfer_id.wizard_view()
+        return action

--- a/stock_packaging_usability_ul/wizard/stock_select_ul.py
+++ b/stock_packaging_usability_ul/wizard/stock_select_ul.py
@@ -26,13 +26,14 @@ from openerp import models, fields, api
 class StockSelectUL(models.TransientModel):
     _name = 'stock.select.ul'
     _description = 'Select UL'
+    _rec_name = 'ul_id'
 
     ul_id = fields.Many2one('product.ul', string='Logistic Unit')
     # required=False, because we accept that it can be left empty
 
     @api.multi
     def validate(self):
-        assert len(self) == 1, 'Only 1 record'
+        self.ensure_one()
         ul = self[0].ul_id
         assert self.env.context.get('pack_function') is not None, \
             'missing context key pack_function'

--- a/stock_packaging_usability_ul/wizard/stock_select_ul.py
+++ b/stock_packaging_usability_ul/wizard/stock_select_ul.py
@@ -1,0 +1,55 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Stock Packaging Usability UL module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields, api
+
+
+class StockSelectUL(models.TransientModel):
+    _name = 'stock.select.ul'
+    _description = 'Select UL'
+
+    ul_id = fields.Many2one('product.ul', string='Logistic Unit')
+    # required=False, because we accept that it can be left empty
+
+    @api.multi
+    def validate(self):
+        assert len(self) == 1, 'Only 1 record'
+        ul = self[0].ul_id
+        assert self.env.context.get('pack_function') is not None, \
+            'missing context key pack_function'
+        self = self.with_context(default_ul_id=(ul and ul.id or False))
+        action = False
+        if self.env.context.get('pack_function') == 'put_residual_in_new_pack':
+            assert self.env.context.get('active_model') == \
+                'stock.transfer_details', 'Wrong underlying model'
+            trf_wiz = self.env['stock.transfer_details'].browse(
+                self.env.context['active_id'])
+            trf_wiz.put_residual_in_new_pack()
+            action = trf_wiz.wizard_view()
+        elif self.env.context.get('pack_function') == 'put_in_pack':
+            assert self.env.context.get('active_model') == \
+                'stock.transfer_details_items', 'Wrong underlying model'
+            trf_line_wiz = self.env['stock.transfer_details_items'].browse(
+                self.env.context['active_id'])
+            trf_line_wiz.put_in_pack()
+            action = trf_line_wiz.transfer_id.wizard_view()
+        return action

--- a/stock_packaging_usability_ul/wizard/stock_select_ul.py
+++ b/stock_packaging_usability_ul/wizard/stock_select_ul.py
@@ -34,7 +34,7 @@ class StockSelectUL(models.TransientModel):
     @api.multi
     def validate(self):
         self.ensure_one()
-        ul = self[0].ul_id
+        ul = self.ul_id
         assert self.env.context.get('pack_function') is not None, \
             'missing context key pack_function'
         self = self.with_context(default_ul_id=(ul and ul.id or False))

--- a/stock_packaging_usability_ul/wizard/stock_select_ul.xml
+++ b/stock_packaging_usability_ul/wizard/stock_select_ul.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright (C) 2014 Akretion (http://www.akretion.com/)
+    @author Alexis de Lattre <alexis.delattre@akretion.com>
+    The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data>
+
+
+<record id="stock_select_ul_form" model="ir.ui.view">
+    <field name="name">stock_packaging_usability_ul.stock_select_ul</field>
+    <field name="model">stock.select.ul</field>
+    <field name="arch" type="xml">
+        <form string="Select Logistical Unit">
+            <group name="main">
+                <field name="ul_id"/>
+            </group>
+            <footer>
+                <button name="validate" type="object"
+                    string="Validate" class="oe_highlight"/>
+                <button special="cancel" string="Cancel" class="oe_link"/>
+            </footer>
+        </form>
+    </field>
+</record>
+
+<record id="stock_select_ul_action" model="ir.actions.act_window">
+    <field name="name">Select Logistical Unit</field>
+    <field name="res_model">stock.select.ul</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+</record>
+
+</data>
+</openerp>

--- a/stock_packaging_usability_ul/wizard/stock_select_ul.xml
+++ b/stock_packaging_usability_ul/wizard/stock_select_ul.xml
@@ -21,7 +21,8 @@
             <footer>
                 <button name="validate" type="object"
                     string="Validate" class="oe_highlight"/>
-                <button special="cancel" string="Cancel" class="oe_link"/>
+                <button name="cancel" type="object"
+                    string="Cancel" class="oe_link"/>
             </footer>
         </form>
     </field>

--- a/stock_packaging_usability_ul/wizard/stock_transfer_details.xml
+++ b/stock_packaging_usability_ul/wizard/stock_transfer_details.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright (C) 2014 Akretion (http://www.akretion.com/)
+    @author Alexis de Lattre <alexis.delattre@akretion.com>
+    The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data>
+
+
+<record id="view_stock_enter_transfer_details" model="ir.ui.view">
+    <field name="name">stock_packaging_usability_ul.stock.transfer_details</field>
+    <field name="model">stock.transfer_details</field>
+    <field name="inherit_id" ref="stock_packaging_usability.view_stock_enter_transfer_details" />
+    <field name="arch" type="xml">
+        <button name="put_residual_in_new_pack" position="attributes">
+            <attribute name="type">action</attribute>
+            <attribute name="name">%(stock_select_ul_action)d</attribute>
+            <attribute name="context">{'pack_function': 'put_residual_in_new_pack'}</attribute>
+        </button>
+        <button name="put_in_pack" position="attributes">
+            <attribute name="type">action</attribute>
+            <attribute name="name">%(stock_select_ul_action)d</attribute>
+            <attribute name="context">{'pack_function': 'put_in_pack'}</attribute>
+        </button>
+    </field>
+</record>
+
+
+</data>
+</openerp>


### PR DESCRIPTION
This contribution includes 2 modules that work together (that's why I put them in the same PR):
1) stock_packaging_usability: it restores the button "Put in current pack" which was native in v7 but is not present in v8, and it adds a button "Put residual in new pack" which puts all the lines that are not already in a pack in one single new pack

2) stock_packaging_usability_ul: it depends on the module stock_packaging_usability and extends it behavior: when you go "put in new pack" or "Put residual in new pack", it will ask you to choose a product.ul (logistical unit) that will be set on the new pack.
