### PR TITLE
[11.0][MIG] Migrate stock_product_ul from 10.0 to 11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
   - VERSION="11.0" TESTS="0" LINT_CHECK="0"
 
 install:
+  - pip install openupgradelib
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly

--- a/stock_product_ul/README.rst
+++ b/stock_product_ul/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
    :alt: License: AGPL-3
 
 ===============

--- a/stock_product_ul/README.rst
+++ b/stock_product_ul/README.rst
@@ -1,0 +1,58 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===============
+Logistics Units
+===============
+
+The object *Logistics Units* (technical name *product.ul*) was defined in the official *product* module until Odoo v8 (cf `this code <https://github.com/odoo/odoo/blob/8.0/addons/product/product.py#L222>`_), but it was dropped in Odoo v9. This module restores this object and ensure compatibility for databases upgraded from Odoo v8 (same object name, same field names). This object allows to define the type of packages and/or pallets that you use to ship the goods. It may be needed to be able to display detailed information on packing lists and/or compute an accurate theorical weight per package that takes into account the weight of the packaging.
+
+It also restores the many2one field *Logistics Unit* (technical name *ul_id*) from *Packages* (technical name *stock.quant.packages*) to *Logistics Units* (technical name *product.ul*).
+
+If you use logistics units, you may also be interested by the module *stock_packaging_usability_ul* that allows to select the logistics unit on the fly when you define a new pack.
+
+Configuration
+=============
+
+Go to the Settings page of the Inventory menu and enable the option
+*Record packages used on packing: pallets, boxes, ...*: it will add all
+users to the group *Manage Packages*.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/152/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/stock-logistics-tracking/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Alexis de Lattre <alexis.delattre@akretion.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/stock_product_ul/README.rst
+++ b/stock_product_ul/README.rst
@@ -41,6 +41,7 @@ Contributors
 ------------
 
 * Alexis de Lattre <alexis.delattre@akretion.com>
+* Gabriel Davini <gabrielfranciscodavini@gmail.com>
 
 Maintainer
 ----------

--- a/stock_product_ul/__init__.py
+++ b/stock_product_ul/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/stock_product_ul/__init__.py
+++ b/stock_product_ul/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import models
+from .hooks import post_init_hook

--- a/stock_product_ul/__init__.py
+++ b/stock_product_ul/__init__.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
 from .hooks import post_init_hook

--- a/stock_product_ul/__manifest__.py
+++ b/stock_product_ul/__manifest__.py
@@ -11,6 +11,9 @@
     'author': 'Akretion,Odoo Community Association (OCA)',
     'website': 'http://www.akretion.com',
     'depends': ['stock'],
+    'external_dependencies': {
+        "python": ['openupgradelib'],
+    },
     'data': [
         'security/ir.model.access.csv',
         'views/product_ul.xml',
@@ -19,4 +22,5 @@
     'demo': ['demo/product_ul.xml'],
     'url': 'https://github.com/OCA/stock-logistics-tracking',
     'installable': True,
+    'post_init_hook': 'post_init_hook',
 }

--- a/stock_product_ul/__manifest__.py
+++ b/stock_product_ul/__manifest__.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     'name': 'Logistics Units',
-    'version': '10.0.1.0.0',
+    'version': '11.0.1.0.0',
     'category': 'Warehouse',
     'license': 'AGPL-3',
     'summary': 'Restore Logisitics Units object',

--- a/stock_product_ul/__manifest__.py
+++ b/stock_product_ul/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Logistics Units',
+    'version': '10.0.1.0.0',
+    'category': 'Warehouse',
+    'license': 'AGPL-3',
+    'summary': 'Restore product.ul object',
+    'author': 'Akretion,Odoo Community Association (OCA)',
+    'website': 'http://www.akretion.com',
+    'depends': ['stock'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/product_ul.xml',
+        'views/stock_quant_package.xml',
+    ],
+    'demo': ['demo/product_ul.xml'],
+    'url': 'https://odoo-community.org/',
+    'installable': True,
+}

--- a/stock_product_ul/__manifest__.py
+++ b/stock_product_ul/__manifest__.py
@@ -7,7 +7,7 @@
     'version': '10.0.1.0.0',
     'category': 'Warehouse',
     'license': 'AGPL-3',
-    'summary': 'Restore product.ul object',
+    'summary': 'Restore Logisitics Units object',
     'author': 'Akretion,Odoo Community Association (OCA)',
     'website': 'http://www.akretion.com',
     'depends': ['stock'],
@@ -17,6 +17,6 @@
         'views/stock_quant_package.xml',
     ],
     'demo': ['demo/product_ul.xml'],
-    'url': 'https://odoo-community.org/',
+    'url': 'https://github.com/OCA/stock-logistics-tracking',
     'installable': True,
 }

--- a/stock_product_ul/demo/product_ul.xml
+++ b/stock_product_ul/demo/product_ul.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<odoo noupdate="1">
+
+
+<record id="box_50x40x30" model="product.ul">
+    <field name="name">Box 50x40x30</field>
+    <field name="type">box</field>
+    <field name="length">50</field>
+    <field name="width">40</field>
+    <field name="height">30</field>
+    <field name="weight">1</field>
+</record>
+
+<record id="pack_30x20x17" model="product.ul">
+    <field name="name">Package 30x20x17</field>
+    <field name="type">pack</field>
+    <field name="length">30</field>
+    <field name="width">20</field>
+    <field name="height">17</field>
+    <field name="weight">0.15</field>
+</record>
+
+<record id="pallet_eur" model="product.ul">
+    <field name="name">EUR-pallet</field>
+    <field name="type">pallet</field>
+    <field name="length">120</field>
+    <field name="width">80</field>
+    <field name="height">14.4</field>
+    <field name="weight">25</field>
+</record>
+
+
+</odoo>

--- a/stock_product_ul/hooks.py
+++ b/stock_product_ul/hooks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/stock_product_ul/hooks.py
+++ b/stock_product_ul/hooks.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgrade import openupgradelib
+
+
+def post_init_hook(cr, registry):
+    # If model data is the former one
+    cr.execute("select 1 from ir_model_data imd"
+               " join ir_model_fields imf on imf.id = imd.res_id AND"
+               " imd.model = 'product.ul'"
+               " WHERE imd.module = 'product'")
+    if cr.fetchall():
+        openupgrade.update_module_moved_fields(
+            cr=cr,
+            model='product.ul',
+            moved_fields=[
+                'name',
+                'type',
+                'length',
+                'width',
+                'height',
+                'weight',
+            ],
+            old_module='product',
+            new_module='stock_product_ul',
+        )

--- a/stock_product_ul/hooks.py
+++ b/stock_product_ul/hooks.py
@@ -9,75 +9,26 @@ except ImportError:
 
 
 def post_init_hook(cr, registry):
+    if not OPENUPGRADE_LIB:
+        return
+
     # If model data is the former one
     cr.execute("select 1 from ir_model_data imd"
                " join ir_model_fields imf on imf.id = imd.res_id AND"
                " imd.model = 'product.ul'"
                " WHERE imd.module = 'product'")
     if cr.fetchall():
-        model = 'product.ul'
-        moved_fields = [
-            'name',
-            'type',
-            'length',
-            'width',
-            'height',
-            'weight',
-        ]
-        old_module = 'product'
-        new_module = 'stock_product_ul'
-        if OPENUPGRADE_LIB:
-            openupgrade.update_module_moved_fields(
-                cr=cr,
-                model=model,
-                moved_fields=moved_fields,
-                old_module=old_module,
-                new_module=new_module,
-            )
-        else:
-            # Raw copy of update_module_moved_fields()
-            vals = {
-                'new_module': new_module,
-                'old_module': old_module,
-                'model': model,
-                'fields': tuple(moved_fields),
-            }
-
-            # update xml-id entries
-            cr.execute(
-                """
-                UPDATE ir_model_data imd
-                SET module = %(new_module)s
-                FROM ir_model_fields imf
-                WHERE
-                    imf.model = %(model)s AND
-                    imf.name IN %(fields)s AND
-                    imd.module = %(old_module)s AND
-                    imd.res_id = imf.id AND
-                    imd.id NOT IN (
-                    SELECT id FROM ir_model_data WHERE module = %(new_module)s
-                    )
-                """,
-                vals,
-            )
-
-            # update ir_translation - it covers both <=v8 through type='field' and
-            # >=v9 through type='model' + name
-            cr.execute(
-                """
-                UPDATE ir_translation it
-                SET module = %(new_module)s
-                FROM ir_model_fields imf
-                WHERE
-                    imf.model = %(model)s AND
-                    imf.name IN %(fields)s AND
-                    it.res_id = imf.id AND
-                    it.module = %(old_module)s AND ((
-                        it.name LIKE 'ir.model.fields,field_%%' AND
-                        it.type = 'model'
-                    ) OR (
-                        it.type = 'field'
-                    ))
-                """,
-                vals,
-            )
+        openupgrade.update_module_moved_fields(
+            cr=cr,
+            model='product.ul',
+            moved_fields=[
+                'name',
+                'type',
+                'length',
+                'width',
+                'height',
+                'weight',
+            ],
+            old_module='product',
+            new_module='stock_product_ul',
+        )

--- a/stock_product_ul/hooks.py
+++ b/stock_product_ul/hooks.py
@@ -1,7 +1,11 @@
 # Copyright 2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openupgradelib import openupgrade
+try:
+    from openupgradelib import openupgrade
+    OPENUPGRADE_LIB = True
+except ImportError:
+    OPENUPGRADE_LIB = False
 
 
 def post_init_hook(cr, registry):
@@ -11,17 +15,69 @@ def post_init_hook(cr, registry):
                " imd.model = 'product.ul'"
                " WHERE imd.module = 'product'")
     if cr.fetchall():
-        openupgrade.update_module_moved_fields(
-            cr=cr,
-            model='product.ul',
-            moved_fields=[
-                'name',
-                'type',
-                'length',
-                'width',
-                'height',
-                'weight',
-            ],
-            old_module='product',
-            new_module='stock_product_ul',
-        )
+        model = 'product.ul'
+        moved_fields = [
+            'name',
+            'type',
+            'length',
+            'width',
+            'height',
+            'weight',
+        ]
+        old_module = 'product'
+        new_module = 'stock_product_ul'
+        if OPENUPGRADE_LIB:
+            openupgrade.update_module_moved_fields(
+                cr=cr,
+                model=model,
+                moved_fields=moved_fields,
+                old_module=old_module,
+                new_module=new_module,
+            )
+        else:
+            # Raw copy of update_module_moved_fields()
+            vals = {
+                'new_module': new_module,
+                'old_module': old_module,
+                'model': model,
+                'fields': tuple(moved_fields),
+            }
+
+            # update xml-id entries
+            cr.execute(
+                """
+                UPDATE ir_model_data imd
+                SET module = %(new_module)s
+                FROM ir_model_fields imf
+                WHERE
+                    imf.model = %(model)s AND
+                    imf.name IN %(fields)s AND
+                    imd.module = %(old_module)s AND
+                    imd.res_id = imf.id AND
+                    imd.id NOT IN (
+                    SELECT id FROM ir_model_data WHERE module = %(new_module)s
+                    )
+                """,
+                vals,
+            )
+
+            # update ir_translation - it covers both <=v8 through type='field' and
+            # >=v9 through type='model' + name
+            cr.execute(
+                """
+                UPDATE ir_translation it
+                SET module = %(new_module)s
+                FROM ir_model_fields imf
+                WHERE
+                    imf.model = %(model)s AND
+                    imf.name IN %(fields)s AND
+                    it.res_id = imf.id AND
+                    it.module = %(old_module)s AND ((
+                        it.name LIKE 'ir.model.fields,field_%%' AND
+                        it.type = 'model'
+                    ) OR (
+                        it.type = 'field'
+                    ))
+                """,
+                vals,
+            )

--- a/stock_product_ul/hooks.py
+++ b/stock_product_ul/hooks.py
@@ -2,7 +2,7 @@
 # Copyright 2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openupgrade import openupgradelib
+from openupgradelib import openupgrade
 
 
 def post_init_hook(cr, registry):

--- a/stock_product_ul/models/__init__.py
+++ b/stock_product_ul/models/__init__.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import product_ul
 from . import stock_quant_package

--- a/stock_product_ul/models/__init__.py
+++ b/stock_product_ul/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import product_ul
+from . import stock_quant_package

--- a/stock_product_ul/models/product_ul.py
+++ b/stock_product_ul/models/product_ul.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+import odoo.addons.decimal_precision as dp
+
+
+class ProductUl(models.Model):
+    _name = 'product.ul'
+    _description = 'Logistics Unit'
+    _order = 'sequence, id'
+
+    name = fields.Char(
+        string='Name', index=True, required=True, translate=True)
+    sequence = fields.Integer(default=10)
+    active = fields.Boolean(default=True)
+    type = fields.Selection([
+        ('unit', 'Unit'),
+        ('pack', 'Pack'),
+        ('box', 'Box'),
+        ('pallet', 'Pallet'),
+        ], string='Type', required=True)
+    length = fields.Float(
+        string='Length', help='Length of the logistics unit in cm')
+    width = fields.Float(
+        string='Width', help='Width of the logistics unit in cm')
+    height = fields.Float(
+        string='Height', help='Height of the logistics unit in cm')
+    weight = fields.Float(
+        string='Empty Package Weight', digits=dp.get_precision('Weight'),
+        help='Package weight in kg.')
+    product_id = fields.Many2one(
+        'product.product', string='Related Product', ondelete='restrict',
+        domain=[('type', 'in', ('product', 'consu'))])
+
+    _sql_constraints = [
+        ('length_positive', 'CHECK(length >= 0)', 'Length must be >= 0'),
+        ('width_positive', 'CHECK(width >= 0)', 'Width must be >= 0'),
+        ('height_positive', 'CHECK(height >= 0)', 'Height must be >= 0'),
+        ('weight_positive', 'CHECK(weight >= 0)', 'Weight must be >= 0'),
+        ]

--- a/stock_product_ul/models/product_ul.py
+++ b/stock_product_ul/models/product_ul.py
@@ -24,7 +24,7 @@ class ProductUl(models.Model):
         string='Type',
         required=True,
     )
-    length = fields.Float(
+    length = fields.Float(  # pylint: disable=W8105
         string='Length', help='Length of the logistics unit in cm')
     width = fields.Float(
         string='Width', help='Width of the logistics unit in cm')

--- a/stock_product_ul/models/product_ul.py
+++ b/stock_product_ul/models/product_ul.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
@@ -15,12 +14,16 @@ class ProductUl(models.Model):
         string='Name', index=True, required=True, translate=True)
     sequence = fields.Integer(default=10)
     active = fields.Boolean(default=True)
-    type = fields.Selection([
-        ('unit', 'Unit'),
-        ('pack', 'Pack'),
-        ('box', 'Box'),
-        ('pallet', 'Pallet'),
-        ], string='Type', required=True)
+    type = fields.Selection(
+        [
+            ('unit', 'Unit'),
+            ('pack', 'Pack'),
+            ('box', 'Box'),
+            ('pallet', 'Pallet'),
+        ],
+        string='Type',
+        required=True,
+    )
     length = fields.Float(
         string='Length', help='Length of the logistics unit in cm')
     width = fields.Float(
@@ -39,4 +42,4 @@ class ProductUl(models.Model):
         ('width_positive', 'CHECK(width >= 0)', 'Width must be >= 0'),
         ('height_positive', 'CHECK(height >= 0)', 'Height must be >= 0'),
         ('weight_positive', 'CHECK(weight >= 0)', 'Weight must be >= 0'),
-        ]
+    ]

--- a/stock_product_ul/models/stock_quant_package.py
+++ b/stock_product_ul/models/stock_quant_package.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/stock_product_ul/models/stock_quant_package.py
+++ b/stock_product_ul/models/stock_quant_package.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class StockQuantPackage(models.Model):
+    _inherit = 'stock.quant.package'
+
+    ul_id = fields.Many2one(
+        'product.ul', string='Logistics Unit', ondelete='restrict')

--- a/stock_product_ul/security/ir.model.access.csv
+++ b/stock_product_ul/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_ul_read,Read access on product.ul to Employees,model_product_ul,base.group_user,1,0,0,0
+access_product_ul_full,Full access on product.ul to Stock Manager,model_product_ul,stock.group_stock_manager,1,1,1,1

--- a/stock_product_ul/views/product_ul.xml
+++ b/stock_product_ul/views/product_ul.xml
@@ -76,7 +76,8 @@
             <separator/>
             <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
             <group string="Group By" name="groupby">
-                <filter name="type_groupby" string="Type" context="{'group_by': 'type'}"/> <!-- TODO trigger a crash 'TypeError: key.indexOf is not a function' => find why -->
+                <filter name="type_groupby" string="Type" context="{'group_by': 'type'}"/>
+                <!-- the above groupby trigger a crash 'TypeError: key.indexOf is not a function' => TODO: find why -->
             </group>
         </search>
     </field>

--- a/stock_product_ul/views/product_ul.xml
+++ b/stock_product_ul/views/product_ul.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<odoo>
+
+<record id="product_ul_form" model="ir.ui.view">
+    <field name="model">product.ul</field>
+    <field name="arch" type="xml">
+        <form string="Logistics Unit">
+            <sheet>
+                <div class="oe_button_box" name="button_box">
+                    <button name="toggle_active" type="object"
+                        class="oe_stat_button" icon="fa-archive">
+                        <field name="active" widget="boolean_button"
+                            options='{"terminology": "archive"}'/>
+                    </button>
+                </div>
+                <div class="oe_title">
+                    <label for="name" class="oe_edit_only"/>
+                    <h1>
+                        <field name="name" class="oe_inline"/>
+                    </h1>
+                </div>
+                <group name="main">
+                    <field name="type"/>
+                    <field name="product_id" context="{'default_name': name, 'default_type': 'product', 'default_purchase_ok': True, 'default_sale_ok': False}"/>
+                    <label for="length"/>
+                    <div name="length">
+                        <field name="length" class="oe_inline"/>
+                        <label string=" cm"/>
+                    </div>
+                    <label for="width"/>
+                    <div name="width">
+                        <field name="width" class="oe_inline"/>
+                        <label string=" cm"/>
+                    </div>
+                    <label for="height"/>
+                    <div name="height">
+                        <field name="height" class="oe_inline"/>
+                        <label string=" cm"/>
+                    </div>
+                    <label for="weight"/>
+                    <div name="weight">
+                        <field name="weight" class="oe_inline"/>
+                        <label string=" kg"/>
+                    </div>
+                </group>
+            </sheet>
+        </form>
+    </field>
+</record>
+
+<record id="product_ul_tree" model="ir.ui.view">
+    <field name="model">product.ul</field>
+    <field name="arch" type="xml">
+        <tree string="Logistics Units">
+            <field name="sequence" widget="handle"/>
+            <field name="name"/>
+            <field name="type"/>
+            <field name="length"/>
+            <field name="width"/>
+            <field name="height"/>
+            <field name="weight"/>
+        </tree>
+    </field>
+</record>
+
+<record id="product_ul_search" model="ir.ui.view">
+    <field name="model">product.ul</field>
+    <field name="arch" type="xml">
+        <search string="Search Logistics Units">
+            <field name="name"/>
+            <separator/>
+            <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
+            <group string="Group By" name="groupby">
+                <filter name="type_groupby" string="Type" context="{'group_by': 'type'}"/> <!-- TODO trigger a crash 'TypeError: key.indexOf is not a function' => find why -->
+            </group>
+        </search>
+    </field>
+</record>
+
+<record id="product_ul_action" model="ir.actions.act_window">
+    <field name="name">Logistics Units</field>
+    <field name="res_model">product.ul</field>
+    <field name="view_mode">tree,form</field>
+</record>
+
+<menuitem id="product_ul_menu"
+    parent="stock.menu_product_in_config_stock"
+    action="product_ul_action"
+    groups="stock.group_tracking_lot"
+    sequence="100"/>
+
+</odoo>

--- a/stock_product_ul/views/stock_quant_package.xml
+++ b/stock_product_ul/views/stock_quant_package.xml
@@ -11,7 +11,7 @@
     <field name="model">stock.quant.package</field>
     <field name="inherit_id" ref="stock.view_quant_package_form"/>
     <field name="arch" type="xml">
-        <field name="packaging_id" position="before">
+        <field name="location_id" position="after">
             <field name="ul_id"/>
         </field>
     </field>

--- a/stock_product_ul/views/stock_quant_package.xml
+++ b/stock_product_ul/views/stock_quant_package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<odoo>
+
+
+<record id="view_quant_package_form" model="ir.ui.view">
+    <field name="model">stock.quant.package</field>
+    <field name="inherit_id" ref="stock.view_quant_package_form"/>
+    <field name="arch" type="xml">
+        <field name="packaging_id" position="before">
+            <field name="ul_id"/>
+        </field>
+    </field>
+</record>
+
+<record id="view_quant_package_tree" model="ir.ui.view">
+    <field name="model">stock.quant.package</field>
+    <field name="inherit_id" ref="stock.view_quant_package_tree"/>
+    <field name="arch" type="xml">
+        <field name="packaging_id" position="before">
+            <field name="ul_id"/>
+        </field>
+    </field>
+</record>
+
+
+
+</odoo>

--- a/stock_product_ul/views/stock_quant_package.xml
+++ b/stock_product_ul/views/stock_quant_package.xml
@@ -28,5 +28,4 @@
 </record>
 
 
-
 </odoo>


### PR DESCRIPTION
Hi!

I've migrated [stock_product_ul](https://github.com/akretion/stock-logistics-tracking/tree/10-ul/stock_product_ul) to v11.0.

Having in mind the discussion on #18 I think that merging those 3 modules into just one is a must as the original usability is actually not very user friendly. That's why I open only one PR.

How do we proceed now? I assume that we need to resolve #17 and #18 before merging this one. I can get down to the work needed for those PR to be solved.

Thank you!