### PR TITLE
[18.0][FIX] stock_quant_package_dimension: Removed weight functionality

### DIFF
--- a/stock_quant_package_dimension/README.rst
+++ b/stock_quant_package_dimension/README.rst
@@ -28,8 +28,7 @@ Stock Quant Package Dimension
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module adds dimension fields on stock packages and an estimated
-weight (in kg).
+This module adds dimension fields on stock packages.
 
 **Table of contents**
 

--- a/stock_quant_package_dimension/models/stock_quant_package.py
+++ b/stock_quant_package_dimension/models/stock_quant_package.py
@@ -18,12 +18,6 @@ class StockQuantPackage(models.Model):
         store=False,
         help="volume",
     )
-    estimated_pack_weight_kg = fields.Float(
-        "Estimated weight (in kg)",
-        digits="Product Unit of Measure",
-        compute="_compute_estimated_pack_weight_kg",
-        help="Based on the weight of the product.",
-    )
 
     length_uom_id = fields.Many2one(
         # Same as product.packing
@@ -141,56 +135,3 @@ class StockQuantPackage(models.Model):
     @api.onchange("product_packaging_id")
     def onchange_product_packaging_id(self):
         self._update_dimensions_from_packaging(override=True)
-
-    def _get_picking_move_line_ids_per_package(self, picking_id):
-        if not picking_id:
-            return {}
-        move_lines = self.env["stock.move.line"].search(
-            [("result_package_id", "in", self.ids), ("picking_id", "=", picking_id)]
-        )
-        res = dict.fromkeys(self.ids, self.env["stock.move.line"])
-        for ml in move_lines:
-            res.setdefault(ml.result_package_id, set(ml.ids))
-            res[ml.result_package_id].add(ml.id)
-        return res
-
-    def _get_weight_kg_from_move_lines(self, move_lines):
-        uom_kg = self.env.ref("uom.product_uom_kgm")
-        return sum(
-            ml.product_uom_id._compute_quantity(
-                qty=ml.quantity, to_unit=ml.product_id.uom_id
-            )
-            * ml.product_id.weight_uom_id._compute_quantity(
-                qty=ml.product_id.weight, to_unit=uom_kg
-            )
-            for ml in move_lines
-        )
-
-    def _get_weight_kg_from_quants(self, quants):
-        uom_kg = self.env.ref("uom.product_uom_kgm")
-        return sum(
-            quant.quantity
-            * quant.product_id.weight_uom_id._compute_quantity(
-                qty=quant.product_id.weight, to_unit=uom_kg
-            )
-            for quant in quants
-        )
-
-    @api.depends("quant_ids")
-    @api.depends_context("picking_id")
-    def _compute_estimated_pack_weight_kg(self):
-        # NOTE: copy-pasted and adapted from `delivery` module
-        # because we do not want to add the dependency against 'delivery' here.
-        picking_id = self.env.context.get("picking_id")
-        move_line_ids_per_package = self._get_picking_move_line_ids_per_package(
-            picking_id
-        )
-        for package in self:
-            weight = 0.0
-            if picking_id:  # coming from a transfer
-                move_line_ids = move_line_ids_per_package.get(package, [])
-                move_lines = self.env["stock.move.line"].browse(move_line_ids)
-                weight = package._get_weight_kg_from_move_lines(move_lines)
-            else:
-                weight = package._get_weight_kg_from_quants(package.quant_ids)
-            package.estimated_pack_weight_kg = weight

--- a/stock_quant_package_dimension/readme/DESCRIPTION.md
+++ b/stock_quant_package_dimension/readme/DESCRIPTION.md
@@ -1,2 +1,1 @@
-This module adds dimension fields on stock packages and an estimated
-weight (in kg).
+This module adds dimension fields on stock packages.

--- a/stock_quant_package_dimension/static/description/index.html
+++ b/stock_quant_package_dimension/static/description/index.html
@@ -370,8 +370,7 @@ ul.auto-toc {
 !! source digest: sha256:cbc154d670c95b802a40aa7b9e0e0127f5997a04f1917c8b375d0dc24bd805eb
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/stock-logistics-tracking/tree/18.0/stock_quant_package_dimension"><img alt="OCA/stock-logistics-tracking" src="https://img.shields.io/badge/github-OCA%2Fstock--logistics--tracking-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/stock-logistics-tracking-18-0/stock-logistics-tracking-18-0-stock_quant_package_dimension"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/stock-logistics-tracking&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module adds dimension fields on stock packages and an estimated
-weight (in kg).</p>
+<p>This module adds dimension fields on stock packages.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/stock_quant_package_dimension/tests/test_package_dimension.py
+++ b/stock_quant_package_dimension/tests/test_package_dimension.py
@@ -51,20 +51,3 @@ class TestStockQuantPackageProductPackaging(common.TestStockQuantPackageCommon):
             self.package,
             [{"pack_length": 12, "width": 13, "height": 14, "pack_weight": 15}],
         )
-
-    def test_package_estimated_pack_weight_kg(self):
-        self.env["stock.quant"]._update_available_quantity(
-            self.product,
-            self.wh.out_type_id.default_location_src_id,
-            7.0,
-            package_id=self.package,
-        )
-        # Weight are taken from product, like the delivery module
-        self.assertEqual(self.package.estimated_pack_weight_kg, 7)
-        self.move._action_assign()
-        self.assertEqual(
-            self.package.with_context(
-                picking_id=self.move.picking_id.id
-            ).estimated_pack_weight_kg,
-            7,
-        )

--- a/stock_quant_package_dimension/views/stock_quant_package.xml
+++ b/stock_quant_package_dimension/views/stock_quant_package.xml
@@ -34,11 +34,6 @@
                             <field name="weight_uom_name" />
                         </span>
                     </div>
-                    <label for="estimated_pack_weight_kg" />
-                    <div class="o_row" name="estimated_pack_weight_kg">
-                        <field name="estimated_pack_weight_kg" />
-                        <span>kg</span>
-                    </div>
                 </group>
                 <group string="Units of Measure">
                     <field name="volume_uom_id" />


### PR DESCRIPTION
Removed the functionality of 'Estimated weight (in kg)' as odoo already provides 'Weight' functionality.
Applied changes as suggested in PR https://github.com/OCA/stock-logistics-tracking/pull/47#pullrequestreview-2892712611