### PR TITLE
[IMP] stock_quant_package_product_packaging: set package type

### DIFF
--- a/stock_quant_package_product_packaging/__manifest__.py
+++ b/stock_quant_package_product_packaging/__manifest__.py
@@ -7,7 +7,7 @@
     "development_status": "Beta",
     "category": "Warehouse Management",
     "website": "https://github.com/OCA/stock-logistics-tracking",
-    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "installable": True,
     "depends": ["stock"],

--- a/stock_quant_package_product_packaging/models/__init__.py
+++ b/stock_quant_package_product_packaging/models/__init__.py
@@ -1,2 +1,4 @@
+from . import product_template
+from . import product_product
 from . import stock_quant_package
 from . import stock_move_line

--- a/stock_quant_package_product_packaging/models/__init__.py
+++ b/stock_quant_package_product_packaging/models/__init__.py
@@ -1,4 +1,5 @@
 from . import product_template
 from . import product_product
+from . import stock_quant
 from . import stock_quant_package
 from . import stock_move_line

--- a/stock_quant_package_product_packaging/models/product_product.py
+++ b/stock_quant_package_product_packaging/models/product_product.py
@@ -1,0 +1,18 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models, tools
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _find_best_packaging(self, quantity):
+        self.ensure_one()
+        packagings = self.env["product.packaging"].search(
+            [("product_id", "=", self.id)], order="qty DESC, sequence ASC"
+        )
+        for packaging in packagings:
+            nb, rem = divmod(quantity, packaging.qty)
+            if tools.float_is_zero(rem, precision_digits=3):
+                return packaging
+        return self.env["product.packaging"]

--- a/stock_quant_package_product_packaging/models/product_product.py
+++ b/stock_quant_package_product_packaging/models/product_product.py
@@ -9,7 +9,8 @@ class ProductProduct(models.Model):
     def _find_best_packaging(self, quantity):
         self.ensure_one()
         packagings = self.env["product.packaging"].search(
-            [("product_id", "=", self.id)], order="qty DESC, sequence ASC"
+            [("product_id", "=", self.id), ("qty", "<=", quantity)],
+            order="qty DESC, sequence ASC",
         )
         for packaging in packagings:
             nb, rem = divmod(quantity, packaging.qty)

--- a/stock_quant_package_product_packaging/models/product_template.py
+++ b/stock_quant_package_product_packaging/models/product_template.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    package_type_id = fields.Many2one(
+        "stock.package.type",
+        string="Package type",
+        help="Defines a 'default' package type for this product to be "
+        "applied on packages without product packagings and on put-away "
+        "computation based on package type for product not in a package",
+    )

--- a/stock_quant_package_product_packaging/models/stock_move_line.py
+++ b/stock_quant_package_product_packaging/models/stock_move_line.py
@@ -7,9 +7,11 @@ class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
     def _action_done(self):
+        source_packages = self.package_id
         res = super()._action_done()
         # _action_done in stock module sometimes delete a move line, we
         # have to check if it still exists before reading/writing on it
         for line in self.exists().filtered(lambda ml: ml.result_package_id):
             line.result_package_id.auto_assign_packaging()
+        source_packages._reset_empty_package_package_type()
         return res

--- a/stock_quant_package_product_packaging/models/stock_move_line.py
+++ b/stock_quant_package_product_packaging/models/stock_move_line.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Camptocamp SA
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import models
 
@@ -11,7 +12,7 @@ class StockMoveLine(models.Model):
         res = super()._action_done()
         # _action_done in stock module sometimes delete a move line, we
         # have to check if it still exists before reading/writing on it
-        for line in self.exists().filtered(lambda ml: ml.result_package_id):
-            line.result_package_id.auto_assign_packaging()
+        dest_packages = self.exists().result_package_id
+        (dest_packages | source_packages).auto_assign_packaging()
         source_packages._reset_empty_package_package_type()
         return res

--- a/stock_quant_package_product_packaging/models/stock_quant.py
+++ b/stock_quant_package_product_packaging/models/stock_quant.py
@@ -9,8 +9,8 @@ class StockQuant(models.Model):
     def move_quants(
         self, location_dest_id=False, package_dest_id=False, message=False, unpack=False
     ):
-        package_ids = self.package_id
+        packages = self.package_id
         res = super().move_quants(location_dest_id, package_dest_id, message, unpack)
         if unpack:
-            package_ids.package_type_id = False
+            packages._reset_empty_package_package_type()
         return res

--- a/stock_quant_package_product_packaging/models/stock_quant.py
+++ b/stock_quant_package_product_packaging/models/stock_quant.py
@@ -1,0 +1,16 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class StockQuant(models.Model):
+    _inherit = "stock.quant"
+
+    def move_quants(
+        self, location_dest_id=False, package_dest_id=False, message=False, unpack=False
+    ):
+        package_ids = self.package_id
+        res = super().move_quants(location_dest_id, package_dest_id, message, unpack)
+        if unpack:
+            package_ids.package_type_id = False
+        return res

--- a/stock_quant_package_product_packaging/models/stock_quant_package.py
+++ b/stock_quant_package_product_packaging/models/stock_quant_package.py
@@ -24,6 +24,18 @@ class StockQuantPackage(models.Model):
     )
     single_product_qty = fields.Float(compute="_compute_single_product")
 
+    @api.model_create_multi
+    def create(self, vals):
+        records = super().create(vals)
+        records._sync_package_type_from_packaging()
+        return records
+
+    def write(self, vals):
+        result = super().write(vals)
+        if vals.get("product_packaging_id"):
+            self._sync_package_type_from_packaging()
+        return result
+
     @api.depends("quant_ids", "quant_ids.product_id")
     def _compute_single_product(self):
         for pack in self:
@@ -52,3 +64,35 @@ class StockQuantPackage(models.Model):
                 )
                 if packaging:
                     pack.write({"product_packaging_id": packaging.id})
+
+            if not pack.package_type_id:
+                # if no package type could be set by auto assign,
+                # fallback on the default product's package type (if any)
+                pack._sync_package_type_from_single_product()
+
+    def _sync_package_type_from_packaging(self):
+        for package in self:
+            if package.package_type_id:
+                # Do not set package type for delivery packages
+                # to not trigger constraint like height requirement
+                # (we are delivering them, not storing them)
+                continue
+            package_type = package.product_packaging_id.package_type_id
+            if not package_type:
+                continue
+            package.package_type_id = package_type
+
+    def _sync_package_type_from_single_product(self):
+        for package in self:
+            if package.package_type_id:
+                # Do not set package type for delivery packages
+                # to not trigger constraint like height requirement
+                # (we are delivering them, not storing them)
+                continue
+            package_type = package.single_product_id.package_type_id
+            best_packaging = package.single_product_id._find_best_packaging(
+                package.single_product_qty
+            )
+            if best_packaging.package_type_id:
+                package_type = best_packaging.package_type_id
+            package.package_type_id = package_type

--- a/stock_quant_package_product_packaging/models/stock_quant_package.py
+++ b/stock_quant_package_product_packaging/models/stock_quant_package.py
@@ -56,19 +56,20 @@ class StockQuantPackage(models.Model):
                 and pack.single_product_id
                 and pack.single_product_qty
             ):
-                pack._assign_packaging(
-                    pack.single_product_id, pack.single_product_qty
-                )
+                pack._assign_packaging(pack.single_product_id, pack.single_product_qty)
 
     def _assign_packaging(self, product, quantity):
         self.ensure_one()
         packaging = product._find_best_packaging(quantity)
         if packaging and packaging.qty == quantity:
-            self.write({"product_packaging_id": packaging.id})
-        elif packaging:
+            # the call to write will trigger a call to _sync_package_type_from_packaging
+            self.product_packaging_id = packaging
+        elif self.product_packaging_id:
+            self.product_packaging_id = False
+        if packaging:
             self._sync_package_type_from_packaging(packaging)
         else:
-            self._sync_package_type_from_single_product()
+            self._sync_package_type_from_single_product(product, quantity)
 
         if not self.package_type_id and product.package_type_id:
             self.package_type_id = product.package_type_id
@@ -85,13 +86,12 @@ class StockQuantPackage(models.Model):
                 continue
             package.package_type_id = package_type
 
-    def _sync_package_type_from_single_product(self):
+    def _sync_package_type_from_single_product(self, product, quantity):
         for package in self:
-            if package.single_product_id and package.package_type_id:
+            if package.package_type_id:
                 # Do not set package type for delivery packages
                 # to not trigger constraint like height requirement
                 # (we are delivering them, not storing them)
                 continue
-
-            package_type = package.single_product_id.package_type_id
-            package.package_type_id = package_type
+            if product.package_type_id:
+                package.package_type_id = product.package_type_id

--- a/stock_quant_package_product_packaging/models/stock_quant_package.py
+++ b/stock_quant_package_product_packaging/models/stock_quant_package.py
@@ -56,11 +56,11 @@ class StockQuantPackage(models.Model):
                 and pack.single_product_id
                 and pack.single_product_qty
             ):
-                pack._assign_package_type(
+                pack._assign_packaging(
                     pack.single_product_id, pack.single_product_qty
                 )
 
-    def _assign_package_type(self, product, quantity):
+    def _assign_packaging(self, product, quantity):
         self.ensure_one()
         packaging = product._find_best_packaging(quantity)
         if packaging and packaging.qty == quantity:

--- a/stock_quant_package_product_packaging/models/stock_quant_package.py
+++ b/stock_quant_package_product_packaging/models/stock_quant_package.py
@@ -95,3 +95,7 @@ class StockQuantPackage(models.Model):
                 continue
             if product.package_type_id:
                 package.package_type_id = product.package_type_id
+
+    def _reset_empty_package_package_type(self):
+        empty_packages = self.filtered(lambda rec: not rec.quant_ids)
+        empty_packages.package_type_id = False

--- a/stock_quant_package_product_packaging/models/stock_quant_package.py
+++ b/stock_quant_package_product_packaging/models/stock_quant_package.py
@@ -27,13 +27,14 @@ class StockQuantPackage(models.Model):
     @api.model_create_multi
     def create(self, vals):
         records = super().create(vals)
-        records._sync_package_type_from_packaging()
+        for rec in records:
+            rec._sync_package_type_from_packaging(rec.product_packaging_id)
         return records
 
     def write(self, vals):
         result = super().write(vals)
         if vals.get("product_packaging_id"):
-            self._sync_package_type_from_packaging()
+            self._sync_package_type_from_packaging(self.product_packaging_id)
         return result
 
     @api.depends("quant_ids", "quant_ids.product_id")
@@ -55,44 +56,42 @@ class StockQuantPackage(models.Model):
                 and pack.single_product_id
                 and pack.single_product_qty
             ):
-                packaging = self.env["product.packaging"].search(
-                    [
-                        ("product_id", "=", pack.single_product_id.id),
-                        ("qty", "=", pack.single_product_qty),
-                    ],
-                    limit=1,
+                pack._assign_package_type(
+                    pack.single_product_id, pack.single_product_qty
                 )
-                if packaging:
-                    pack.write({"product_packaging_id": packaging.id})
 
-            if not pack.package_type_id:
-                # if no package type could be set by auto assign,
-                # fallback on the default product's package type (if any)
-                pack._sync_package_type_from_single_product()
+    def _assign_package_type(self, product, quantity):
+        self.ensure_one()
+        packaging = product._find_best_packaging(quantity)
+        if packaging and packaging.qty == quantity:
+            self.write({"product_packaging_id": packaging.id})
+        elif packaging:
+            self._sync_package_type_from_packaging(packaging)
+        else:
+            self._sync_package_type_from_single_product()
 
-    def _sync_package_type_from_packaging(self):
+        if not self.package_type_id and product.package_type_id:
+            self.package_type_id = product.package_type_id
+
+    def _sync_package_type_from_packaging(self, packaging):
         for package in self:
             if package.package_type_id:
                 # Do not set package type for delivery packages
                 # to not trigger constraint like height requirement
                 # (we are delivering them, not storing them)
                 continue
-            package_type = package.product_packaging_id.package_type_id
+            package_type = packaging.package_type_id
             if not package_type:
                 continue
             package.package_type_id = package_type
 
     def _sync_package_type_from_single_product(self):
         for package in self:
-            if package.package_type_id:
+            if package.single_product_id and package.package_type_id:
                 # Do not set package type for delivery packages
                 # to not trigger constraint like height requirement
                 # (we are delivering them, not storing them)
                 continue
+
             package_type = package.single_product_id.package_type_id
-            best_packaging = package.single_product_id._find_best_packaging(
-                package.single_product_qty
-            )
-            if best_packaging.package_type_id:
-                package_type = best_packaging.package_type_id
             package.package_type_id = package_type

--- a/stock_quant_package_product_packaging/models/stock_quant_package.py
+++ b/stock_quant_package_product_packaging/models/stock_quant_package.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Camptocamp SA
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import api, fields, models
 
@@ -6,12 +7,6 @@ from odoo import api, fields, models
 class StockQuantPackage(models.Model):
     _inherit = "stock.quant.package"
 
-    # This is not the same thing as 'packaging_id':
-    # * packaging_id is the "Package type", packaging which have
-    #   no 'product_id' and used for the delivery (postal 2kg, ...)
-    # * product_packaging_id is the actual Product Packaging (usually
-    #   using a GTIN) used for the internal logistics/reception. It
-    #   has a product_id
     product_packaging_id = fields.Many2one(
         "product.packaging",
         "Product Packaging",
@@ -51,12 +46,10 @@ class StockQuantPackage(models.Model):
 
     def auto_assign_packaging(self):
         for pack in self:
-            if (
-                not pack.product_packaging_id
-                and pack.single_product_id
-                and pack.single_product_qty
-            ):
+            if pack.single_product_id and pack.single_product_qty:
                 pack._assign_packaging(pack.single_product_id, pack.single_product_qty)
+            elif pack.product_packaging_id and not pack.single_product_id:
+                pack.product_packaging_id = False
 
     def _assign_packaging(self, product, quantity):
         self.ensure_one()

--- a/stock_quant_package_product_packaging/readme/CONTRIBUTORS.md
+++ b/stock_quant_package_product_packaging/readme/CONTRIBUTORS.md
@@ -1,3 +1,6 @@
 - Akim Juillerat \<<akim.juillerat@camptocamp.com>\>
 - Fernando La Chica - GreenIce \<<fernandolachica@gmail.com>\>
 - Denis Roussel \<<denis.roussel@acsone.eu>\>
+- Alexandre Fayolle \<<alexandre.fayolle@camptocamp.com>\>
+- Jacques-Etienne Baudoux \<<je@bcim.be>\>
+- Guewen Baconnier \<<guewen.baconnier@camptocamp.com>\>

--- a/stock_quant_package_product_packaging/readme/DESCRIPTION.md
+++ b/stock_quant_package_product_packaging/readme/DESCRIPTION.md
@@ -5,3 +5,6 @@ the sum of the quants quantities is equal to the Packaging quantity.
 
 If such a packaging exists, it will be automatically assigned to a
 package after the move is set to done.
+
+The module also computes the package type of the package when products are put in a package. 
+The computation is done based on the number of products in the package. 

--- a/stock_quant_package_product_packaging/tests/__init__.py
+++ b/stock_quant_package_product_packaging/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_stock_quant_package_product_packaging
+from . import test_auto_assign_package_type

--- a/stock_quant_package_product_packaging/tests/common.py
+++ b/stock_quant_package_product_packaging/tests/common.py
@@ -1,0 +1,92 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests import TransactionCase
+
+
+class TestPackageTypeCommon(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        ref = cls.env.ref
+        cls.warehouse = ref("stock.warehouse0")
+        # set two steps reception on warehouse
+        cls.warehouse.reception_steps = "two_steps"
+
+        cls.suppliers_location = ref("stock.stock_location_suppliers")
+        cls.input_location = ref("stock.stock_location_company")
+        cls.stock_location = ref("stock.stock_location_stock")
+        cls.pallet_location = cls.env["stock.location"].create(
+            {"name": "Pallets", "location_id": cls.stock_location.id}
+        )
+
+        cls.env["stock.location"]._parent_store_compute()
+
+        cls.receipts_picking_type = ref("stock.picking_type_in")
+        cls.internal_picking_type = ref("stock.picking_type_internal")
+
+        cls.product = ref("product.product_product_9")
+        cls.product_lot = ref("stock.product_cable_management_box")
+
+        cls.package_type_pallets = cls.env["stock.package.type"].create(
+            {"name": "Pallets"}
+        )
+        cls.package_type_cardboxes = cls.env["stock.package.type"].create(
+            {"name": "Cardboxes"}
+        )
+
+        cls.product_cardbox_product_packaging = cls.env["product.packaging"].create(
+            {
+                "name": "4 units cardbox",
+                "qty": 4,
+                "product_id": cls.product.id,
+                "package_type_id": cls.package_type_cardboxes.id,
+            }
+        )
+        cls.product_single_bag_product_packaging = cls.env["product.packaging"].create(
+            {
+                "name": "Single Bag",
+                "qty": 1,
+                "product_id": cls.product.id,
+            }
+        )
+        cls.product_pallet_product_packaging = cls.env["product.packaging"].create(
+            {
+                "name": "Pallet",
+                "qty": 48,
+                "product_id": cls.product.id,
+                "package_type_id": cls.package_type_pallets.id,
+            }
+        )
+
+        cls.internal_picking_type.write({"show_entire_packs": True})
+        cls.receipts_picking_type.show_entire_packs = True
+
+    @classmethod
+    def _update_qty_in_location(
+        cls, location, product, quantity, package=None, lot=None
+    ):
+        quants = cls.env["stock.quant"]._gather(
+            product, location, lot_id=lot, package_id=package, strict=True
+        )
+        # this method adds the quantity to the current quantity, so remove it
+        quantity -= sum(quants.mapped("quantity"))
+        cls.env["stock.quant"]._update_available_quantity(
+            product, location, quantity, package_id=package, lot_id=lot
+        )
+
+    @classmethod
+    def _create_single_move(cls, product, quantity=2.0):
+        picking_type = cls.warehouse.int_type_id
+        move_vals = {
+            "name": product.name,
+            "picking_type_id": picking_type.id,
+            "product_id": product.id,
+            "product_uom_qty": quantity,
+            "product_uom": product.uom_id.id,
+            "location_id": cls.input_location.id,
+            "location_dest_id": picking_type.default_location_dest_id.id,
+            "state": "confirmed",
+            "procure_method": "make_to_stock",
+        }
+        return cls.env["stock.move"].create(move_vals)

--- a/stock_quant_package_product_packaging/tests/test_auto_assign_package_type.py
+++ b/stock_quant_package_product_packaging/tests/test_auto_assign_package_type.py
@@ -24,7 +24,22 @@ class TestAutoAssignPackageType(TestPackageTypeCommon):
         package = self.env["stock.quant.package"].create(
             {"name": "TEST", "product_packaging_id": self.product_packaging.id}
         )
+
         self.assertEqual(package.package_type_id, self.package_type)
+
+    def test_unpack_package_reset_package_type(self):
+        """When the quants are moved out of a package, the package type is reset"""
+        package = self.env["stock.quant.package"].create(
+            {"name": "TEST", "product_packaging_id": self.product_packaging.id}
+        )
+
+        self._update_qty_in_location(
+            self.warehouse.lot_stock_id, self.product, 5, package=package
+        )
+
+        quants = package.quant_ids
+        quants.move_quants(location_dest_id=self.warehouse.lot_stock_id, unpack=True)
+        self.assertFalse(package.package_type_id)
 
     def test_auto_assign_packaging(self):
         """

--- a/stock_quant_package_product_packaging/tests/test_auto_assign_package_type.py
+++ b/stock_quant_package_product_packaging/tests/test_auto_assign_package_type.py
@@ -1,0 +1,133 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from .common import TestPackageTypeCommon
+
+
+class TestAutoAssignPackageType(TestPackageTypeCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product_packaging = cls.product_pallet_product_packaging
+        cls.package_type = cls.product_packaging.package_type_id
+
+        # Create a new package type for auto assignation
+        vals = {
+            "name": "Auto Assigned Package Type",
+        }
+        cls.auto_assigned_package_type = cls.env["stock.package.type"].create(vals)
+
+    def test_auto_assign_package_type_without_packaging_id(self):
+        """Packages without `packaging_id` are internal packages and they
+        are intended to be stored in the warehouse.
+        On such packages, a package type is automatically defined.
+        """
+        package = self.env["stock.quant.package"].create(
+            {"name": "TEST", "product_packaging_id": self.product_packaging.id}
+        )
+        self.assertEqual(package.package_type_id, self.package_type)
+
+    def test_auto_assign_packaging(self):
+        """
+        Test the auto assignation for package type from
+        the default package type on the product
+
+        - Set the default package type on the product
+        - Create a move and validate it
+        - The package type should be set on package
+        """
+
+        # Set a default package on the product
+        self.product.package_type_id = self.auto_assigned_package_type
+
+        confirmed_move = self._create_single_move(self.product)
+        confirmed_move.location_dest_id = self.pallet_location
+        confirmed_move._assign_picking()
+        self._update_qty_in_location(
+            confirmed_move.location_id,
+            confirmed_move.product_id,
+            confirmed_move.product_qty,
+        )
+        confirmed_move._action_assign()
+        picking = confirmed_move.picking_id
+        picking.action_confirm()
+        picking.move_line_ids.picked = True
+        first_package = picking.action_put_in_pack()
+
+        picking.button_validate()
+
+        self.assertEqual(self.auto_assigned_package_type, first_package.package_type_id)
+
+    def test_auto_assign_no_packaging(self):
+        """
+        Test the non auto assignation for package type from
+        the default package type on the product
+
+        - Unset the default package type on the product
+        - Create a move and validate it
+        - The package type should not be set on package
+        """
+
+        # Set a default package on the product
+        self.product.package_type_id = False
+
+        confirmed_move = self._create_single_move(self.product)
+        confirmed_move.location_dest_id = self.stock_location
+        confirmed_move._assign_picking()
+        self._update_qty_in_location(
+            confirmed_move.location_id,
+            confirmed_move.product_id,
+            confirmed_move.product_qty,
+        )
+        confirmed_move._action_assign()
+        picking = confirmed_move.picking_id
+        picking.action_confirm()
+        picking.move_line_ids.picked = True
+        first_package = picking.action_put_in_pack()
+
+        picking.button_validate()
+
+        self.assertFalse(first_package.package_type_id)
+
+    def test_auto_assign_packaging_pallet(self):
+        """
+        Test the auto assignation for package type from the quantity packaged
+        """
+
+        # Set a default package on the product
+        self.product.package_type_id = self.auto_assigned_package_type
+
+        confirmed_move = self._create_single_move(self.product, quantity=48)
+        confirmed_move.location_dest_id = self.pallet_location
+        confirmed_move._assign_picking()
+        self._update_qty_in_location(
+            confirmed_move.location_id,
+            confirmed_move.product_id,
+            confirmed_move.product_qty,
+        )
+        confirmed_move._action_assign()
+        picking = confirmed_move.picking_id
+        picking.action_confirm()
+        picking.move_line_ids.picked = True
+        first_package = picking.action_put_in_pack()
+
+        picking.button_validate()
+        self.assertEqual(
+            self.product_pallet_product_packaging.package_type_id,
+            first_package.package_type_id,
+        )
+
+    def test_find_best_packaging_pallet(self):
+        packaging = self.product._find_best_packaging(48)
+        self.assertEqual(packaging, self.product_pallet_product_packaging)
+
+    def test_find_best_packaging_cardbox(self):
+        packaging = self.product._find_best_packaging(4)
+        self.assertEqual(packaging, self.product_cardbox_product_packaging)
+
+    def test_find_best_packaging_single(self):
+        packaging = self.product._find_best_packaging(5)
+        self.assertEqual(packaging, self.product_single_bag_product_packaging)
+
+    def test_find_best_packaging_no_match(self):
+        packaging = self.product._find_best_packaging(5.5)
+        self.assertFalse(packaging)

--- a/stock_quant_package_product_packaging/tests/test_stock_quant_package_product_packaging.py
+++ b/stock_quant_package_product_packaging/tests/test_stock_quant_package_product_packaging.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp SA
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo.tests import TransactionCase
 
@@ -61,3 +62,67 @@ class TestStockQuantPackageProductPackaging(TransactionCase):
         self.assertEqual(second_package.single_product_qty, 20.0)
         self.assertEqual(first_package.product_packaging_id, self.packaging)
         self.assertFalse(second_package.product_packaging_id)
+        # Add product to first package
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.receipt_picking_type.id,
+                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_dest_id": location_dest.id,
+            }
+        )
+        picking._onchange_picking_type()
+        picking.write(
+            {
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "TEST",
+                            "product_id": self.product.id,
+                            "product_uom_qty": 5.0,
+                            "product_uom": self.product.uom_id.id,
+                            "location_id": picking.location_id.id,
+                            "location_dest_id": picking.location_dest_id.id,
+                        },
+                    )
+                ]
+            }
+        )
+        picking.action_confirm()
+        picking.action_assign()
+        picking.move_line_ids.result_package_id = first_package
+        picking.button_validate()
+        self.assertFalse(first_package.product_packaging_id)
+        # Remove product from first package
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.receipt_picking_type.id,
+                "location_id": location_dest.id,
+                "location_dest_id": self.env.ref("stock.stock_location_suppliers").id,
+            }
+        )
+        picking._onchange_picking_type()
+        picking.write(
+            {
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "TEST",
+                            "product_id": self.product.id,
+                            "product_uom_qty": 5.0,
+                            "product_uom": self.product.uom_id.id,
+                            "location_id": picking.location_dest_id.id,
+                            "location_dest_id": picking.location_id.id,
+                        },
+                    )
+                ]
+            }
+        )
+        picking.action_confirm()
+        picking.action_assign()
+        picking.move_line_ids.package_id = first_package
+        picking.button_validate()
+        self.assertEqual(first_package.product_packaging_id, self.packaging)


### PR DESCRIPTION
This module includes code extracted from `stock_storage_type` (https://github.com/OCA/stock-logistics-putaway/) because it can be useful to get a value for the `package_type_id` field of `stock.quant.package` without pulling the storage type logic.