### PR TITLE
[18.0] Revert "[FIX] stock_quant_package_dimension: Removed weight functionality."

### DIFF
--- a/stock_quant_package_dimension/README.rst
+++ b/stock_quant_package_dimension/README.rst
@@ -32,7 +32,8 @@ Stock Quant Package Dimension
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module adds dimension fields on stock packages.
+This module adds dimension fields on stock packages and an estimated
+weight (in kg).
 
 **Table of contents**
 

--- a/stock_quant_package_dimension/models/stock_quant_package.py
+++ b/stock_quant_package_dimension/models/stock_quant_package.py
@@ -18,6 +18,12 @@ class StockQuantPackage(models.Model):
         store=False,
         help="volume",
     )
+    estimated_pack_weight_kg = fields.Float(
+        "Estimated weight (in kg)",
+        digits="Product Unit of Measure",
+        compute="_compute_estimated_pack_weight_kg",
+        help="Based on the weight of the product.",
+    )
 
     length_uom_id = fields.Many2one(
         # Same as product.packing
@@ -135,3 +141,56 @@ class StockQuantPackage(models.Model):
     @api.onchange("product_packaging_id")
     def onchange_product_packaging_id(self):
         self._update_dimensions_from_packaging(override=True)
+
+    def _get_picking_move_line_ids_per_package(self, picking_id):
+        if not picking_id:
+            return {}
+        move_lines = self.env["stock.move.line"].search(
+            [("result_package_id", "in", self.ids), ("picking_id", "=", picking_id)]
+        )
+        res = dict.fromkeys(self.ids, self.env["stock.move.line"])
+        for ml in move_lines:
+            res.setdefault(ml.result_package_id, set(ml.ids))
+            res[ml.result_package_id].add(ml.id)
+        return res
+
+    def _get_weight_kg_from_move_lines(self, move_lines):
+        uom_kg = self.env.ref("uom.product_uom_kgm")
+        return sum(
+            ml.product_uom_id._compute_quantity(
+                qty=ml.quantity, to_unit=ml.product_id.uom_id
+            )
+            * ml.product_id.weight_uom_id._compute_quantity(
+                qty=ml.product_id.weight, to_unit=uom_kg
+            )
+            for ml in move_lines
+        )
+
+    def _get_weight_kg_from_quants(self, quants):
+        uom_kg = self.env.ref("uom.product_uom_kgm")
+        return sum(
+            quant.quantity
+            * quant.product_id.weight_uom_id._compute_quantity(
+                qty=quant.product_id.weight, to_unit=uom_kg
+            )
+            for quant in quants
+        )
+
+    @api.depends("quant_ids")
+    @api.depends_context("picking_id")
+    def _compute_estimated_pack_weight_kg(self):
+        # NOTE: copy-pasted and adapted from `delivery` module
+        # because we do not want to add the dependency against 'delivery' here.
+        picking_id = self.env.context.get("picking_id")
+        move_line_ids_per_package = self._get_picking_move_line_ids_per_package(
+            picking_id
+        )
+        for package in self:
+            weight = 0.0
+            if picking_id:  # coming from a transfer
+                move_line_ids = move_line_ids_per_package.get(package, [])
+                move_lines = self.env["stock.move.line"].browse(move_line_ids)
+                weight = package._get_weight_kg_from_move_lines(move_lines)
+            else:
+                weight = package._get_weight_kg_from_quants(package.quant_ids)
+            package.estimated_pack_weight_kg = weight

--- a/stock_quant_package_dimension/readme/DESCRIPTION.md
+++ b/stock_quant_package_dimension/readme/DESCRIPTION.md
@@ -1,1 +1,2 @@
-This module adds dimension fields on stock packages.
+This module adds dimension fields on stock packages and an estimated
+weight (in kg).

--- a/stock_quant_package_dimension/tests/test_package_dimension.py
+++ b/stock_quant_package_dimension/tests/test_package_dimension.py
@@ -51,3 +51,20 @@ class TestStockQuantPackageProductPackaging(common.TestStockQuantPackageCommon):
             self.package,
             [{"pack_length": 12, "width": 13, "height": 14, "pack_weight": 15}],
         )
+
+    def test_package_estimated_pack_weight_kg(self):
+        self.env["stock.quant"]._update_available_quantity(
+            self.product,
+            self.wh.out_type_id.default_location_src_id,
+            7.0,
+            package_id=self.package,
+        )
+        # Weight are taken from product, like the delivery module
+        self.assertEqual(self.package.estimated_pack_weight_kg, 7)
+        self.move._action_assign()
+        self.assertEqual(
+            self.package.with_context(
+                picking_id=self.move.picking_id.id
+            ).estimated_pack_weight_kg,
+            7,
+        )

--- a/stock_quant_package_dimension/views/stock_quant_package.xml
+++ b/stock_quant_package_dimension/views/stock_quant_package.xml
@@ -34,6 +34,11 @@
                             <field name="weight_uom_name" />
                         </span>
                     </div>
+                    <label for="estimated_pack_weight_kg" />
+                    <div class="o_row" name="estimated_pack_weight_kg">
+                        <field name="estimated_pack_weight_kg" />
+                        <span>kg</span>
+                    </div>
                 </group>
                 <group string="Units of Measure">
                     <field name="volume_uom_id" />


### PR DESCRIPTION
This reverts commit d3d646d1fa529e10a333bbb0b3f2412a3f709344.

The feature was not ported to another module, so recovering it here.

This fixes the module stock_storage_type that relies on this estimated weight field