### PR TITLE
[18.0][IMP] stock_quant_package_product_packaging: imp reset package type

### DIFF
--- a/stock_quant_package_product_packaging/models/stock_quant_package.py
+++ b/stock_quant_package_product_packaging/models/stock_quant_package.py
@@ -18,6 +18,9 @@ class StockQuantPackage(models.Model):
         "product.product", compute="_compute_single_product"
     )
     single_product_qty = fields.Float(compute="_compute_single_product")
+    reset_package_type = fields.Boolean(
+        default=True, help="When set the package type will be reset on unpacking"
+    )
 
     @api.model_create_multi
     def create(self, vals):
@@ -90,5 +93,7 @@ class StockQuantPackage(models.Model):
                 package.package_type_id = product.package_type_id
 
     def _reset_empty_package_package_type(self):
-        empty_packages = self.filtered(lambda rec: not rec.quant_ids)
+        empty_packages = self.filtered(
+            lambda rec: not rec.quant_ids and rec.reset_package_type
+        )
         empty_packages.package_type_id = False

--- a/stock_quant_package_product_packaging/tests/test_auto_assign_package_type.py
+++ b/stock_quant_package_product_packaging/tests/test_auto_assign_package_type.py
@@ -41,6 +41,22 @@ class TestAutoAssignPackageType(TestPackageTypeCommon):
         quants.move_quants(location_dest_id=self.warehouse.lot_stock_id, unpack=True)
         self.assertFalse(package.package_type_id)
 
+    def test_unpack_package_no_reset_package_type(self):
+        """Check quants moved out of a package, the package type is NOT reset."""
+        package = self.env["stock.quant.package"].create(
+            {
+                "name": "TEST",
+                "product_packaging_id": self.product_packaging.id,
+                "reset_package_type": False,
+            }
+        )
+        self._update_qty_in_location(
+            self.warehouse.lot_stock_id, self.product, 5, package=package
+        )
+        quants = package.quant_ids
+        quants.move_quants(location_dest_id=self.warehouse.lot_stock_id, unpack=True)
+        self.assertTrue(package.package_type_id)
+
     def test_auto_assign_packaging(self):
         """
         Test the auto assignation for package type from

--- a/stock_quant_package_product_packaging/views/stock_quant_package.xml
+++ b/stock_quant_package_product_packaging/views/stock_quant_package.xml
@@ -5,6 +5,9 @@
         <field name="model">stock.quant.package</field>
         <field name="inherit_id" ref="stock.view_quant_package_form" />
         <field name="arch" type="xml">
+            <field name="package_type_id" position="before">
+                <field name="reset_package_type" />
+            </field>
             <field name="company_id" position="before">
                 <field name="single_product_id" invisible="1" />
                 <field name="single_product_qty" invisible="1" />
@@ -12,6 +15,17 @@
                     name="product_packaging_id"
                     domain="[('product_id', '=', single_product_id), ('qty', '=', single_product_qty)]"
                 />
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="stock_quant_package_tree_view">
+        <field name="name">stock.quant.package.tree.package.reusable</field>
+        <field name="model">stock.quant.package</field>
+        <field name="inherit_id" ref="stock.view_quant_package_tree" />
+        <field name="arch" type="xml">
+            <field name="package_type_id" position="before">
+                <field name="reset_package_type" optional="hide" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Only reset the package type of disposable package. In this way reusable package will keep their type.